### PR TITLE
Add filter for known Palo Alto subnets that do a lot of scanning

### DIFF
--- a/libcorsaro/libcorsaro_filtering.h
+++ b/libcorsaro/libcorsaro_filtering.h
@@ -200,6 +200,10 @@ typedef enum {
      *  packet (so is more likely to be spoofed?) */
     CORSARO_FILTERID_TTL_200_NONSPOOFED,
 
+    /** Matches if the source IP belongs to one of the known subnets that
+     *  Palo Alto uses for periodic large scale scanning
+     */
+    CORSARO_FILTERID_PALOALTO_SUBNET,
     /* XXX PLEASE ADD ALL FUTURE FILTERS HERE */
 
     /** Special reserved ID for the "last" filter -- this should always


### PR DESCRIPTION
Credit to Xie Qiu who helped discover that this subnet was responsible and investigated whether a more general (i.e. non-IP based) filter might have been feasible instead.